### PR TITLE
Fix incorrect tests

### DIFF
--- a/kdt.cabal
+++ b/kdt.cabal
@@ -50,6 +50,7 @@ Test-Suite StaticTest
   ghc-options:          -Wall -O3
   build-depends:        base >=4.6 && <5,
                         kdt -any,
+                        containers >= 0.6.0.1,
                         QuickCheck >=2.5,
                         deepseq >=1.3,
                         deepseq-generics >=0.2.0.0
@@ -63,6 +64,7 @@ Test-Suite DynamicTest
   ghc-options:          -Wall -O3
   build-depends:        base >=4.6 && <5,
                         kdt -any,
+                        containers >= 0.6.0.1,
                         QuickCheck >=2.5,
                         deepseq >=1.3,
                         deepseq-generics >=0.2.0.0


### PR DESCRIPTION
Fixes #7.

The tests assumed that `nearest` can have only 1 result. But that's wrong: There can be more than 1 nearest point to a given query point, and the KD-tree does not necessarily return the same one as a linear search through the list.

Tests for finding the k nearest results have the same problem.

This commit fixes it by making the list-based search return all allowed solutions, and checking that the KD result is among them.

For that, also:

* Rename `*EqualToLinear` to `*ConsistentWithLinear` functions.
* Test the dynamic KD tree not against the static one for tests where that is impossible (e.g. "n nearest" from static might be a different n points than from dynamic, while still a correct result); instead also test against linear search through possible results, as done in the tests for the dynamic KD tree.
* Increase `maxSuccess`, otherwise the failures are too rare to reliably test.